### PR TITLE
fix: ESLint *.tsx 확장자 버그 개선

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 build/*
+node_modules/*
 public/*
 src/react-app-env.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,7 +4,8 @@ module.exports = {
     es2021: true,
   },
   extends: [
-    'plugin:react/recommended',
+    'plugin:@typescript-eslint/eslint-recommended',
+    // 'plugin:react/recommended',
     'airbnb',
   ],
   parser: '@typescript-eslint/parser',
@@ -19,7 +20,13 @@ module.exports = {
     'react',
     '@typescript-eslint',
   ],
+  settings: {
+    'import/resolver': {
+      typescript: {},
+    },
+  },
   rules: {
+    'import/no-unresolved': 'off',
     'react/jsx-filename-extension': [2, { extensions: ['.js', '.jsx', '.ts', '.tsx'] }],
     indent: ['error', 2],
     curly: 'error',
@@ -44,5 +51,15 @@ module.exports = {
     'key-spacing': ['error', { mode: 'strict' }],
     'linebreak-style': 'off',
     'no-proto': 'off',
+    'import/extensions': [
+      'error',
+      'ignorePackages',
+      {
+        js: 'never',
+        jsx: 'never',
+        ts: 'never',
+        tsx: 'never',
+      },
+    ],
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
-        "@types/node": "^16.11.43",
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
         "react": "^18.2.0",
@@ -22,6 +21,7 @@
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
+        "@types/node": "^18.0.3",
         "@typescript-eslint/eslint-plugin": "^5.30.5",
         "@typescript-eslint/parser": "^5.30.5",
         "eslint": "^8.19.0",
@@ -3758,9 +3758,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "node_modules/@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ=="
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
     },
     "node_modules/@types/parse-json": {
       "version": "4.0.0",
@@ -19788,9 +19788,9 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw=="
     },
     "@types/node": {
-      "version": "16.11.43",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.43.tgz",
-      "integrity": "sha512-GqWykok+3uocgfAJM8imbozrqLnPyTrpFlrryURQlw1EesPUCx5XxTiucWDSFF9/NUEXDuD4bnvHm8xfVGWTpQ=="
+      "version": "18.0.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.0.3.tgz",
+      "integrity": "sha512-HzNRZtp4eepNitP+BD6k2L6DROIDG4Q0fm4x+dwfsr6LGmROENnok75VGw40628xf+iR24WeMFcHuuBDUAzzsQ=="
     },
     "@types/parse-json": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
-    "@types/node": "^16.11.43",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",
     "react": "^18.2.0",
@@ -43,6 +42,7 @@
     ]
   },
   "devDependencies": {
+    "@types/node": "^18.0.3",
     "@typescript-eslint/eslint-plugin": "^5.30.5",
     "@typescript-eslint/parser": "^5.30.5",
     "eslint": "^8.19.0",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -4,10 +4,10 @@ import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById('root') as HTMLElement,
 );
 root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>
+  </React.StrictMode>,
 );


### PR DESCRIPTION
import 구분에서 .tsx 확장자 필수 요구하는 부분 개선.
.eslintrc.js에 다음과 같은 규칙 추가.
```javascript
'import/extensions': [
  'error',
  'ignorePackages',
  {
    js: 'never',
    jsx: 'never',
    ts: 'never',
    tsx: 'never',
  },
],
```
