### PR TITLE
feat: 캠프 신청 페이지 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import CommonLayout from './commons/layouts/CommonLayout';
 
 import Home from './pages/Home/Home';
 import CampDetails from './pages/CampDetail/CampDetails';
+import CampApply from './pages/CampApply/CampApply';
 
 import NotFound from './commons/errors/NotFound';
 
@@ -17,6 +18,7 @@ function App() {
       </Route>
       <Route element={<CommonLayout />}>
         <Route path="/detail" element={<CampDetails />} />
+        <Route path="/apply" element={<CampApply />} />
       </Route>
       <Route path="*" element={<NotFound />} />
     </Routes>

--- a/src/pages/CampApply/CampApply.tsx
+++ b/src/pages/CampApply/CampApply.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import MentoIntro from './components/MentoIntro';
+import MenteeIntro from './components/MenteeIntro';
+
+function CampApply() {
+  return (
+    <div>
+      <h1>CampApply</h1>
+      <MentoIntro />
+      <MenteeIntro />
+    </div>
+  );
+}
+
+export default CampApply;

--- a/src/pages/CampApply/components/MenteeIntro.tsx
+++ b/src/pages/CampApply/components/MenteeIntro.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+function MenteeIntro() {
+  return (
+    <div>
+      <h1>MenteeIntro</h1>
+      <h3>신청자 정보</h3>
+
+      <label htmlFor="name">
+        이름
+        <input
+          type="text"
+          name="name"
+          id="name"
+          placeholder="코멘티"
+        />
+      </label>
+
+      <label htmlFor="phone">
+        연락처
+        <input
+          type="text"
+          name="phone"
+          id="phone"
+          placeholder="010-1234-5678"
+        />
+      </label>
+
+      <label htmlFor="email">
+        이메일
+        <input
+          type="text"
+          name="email"
+          id="email"
+          placeholder="colab@example.com"
+        />
+      </label>
+    </div>
+  );
+}
+
+export default MenteeIntro;

--- a/src/pages/CampApply/components/MenteeIntro.tsx
+++ b/src/pages/CampApply/components/MenteeIntro.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 
 function MenteeIntro() {
+  const handleClick = () => {
+    alert('신청이 완료 되었습니다.');
+  };
+
   return (
     <div>
       <h1>MenteeIntro</h1>
@@ -35,6 +39,14 @@ function MenteeIntro() {
           placeholder="colab@example.com"
         />
       </label>
+
+      <button
+        type="button"
+        onClick={handleClick}
+      >
+        다음
+
+      </button>
     </div>
   );
 }

--- a/src/pages/CampApply/components/MentoIntro.tsx
+++ b/src/pages/CampApply/components/MentoIntro.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+function MentoIntro() {
+  return (
+    <div>
+      <h1>MentoIntro</h1>
+      <h3>만나서 반가워요</h3>
+      <div>
+        저는 프로그래밍 5~7년차 멘토입니다.
+        React 실무 교육에 관심을 가져주셔서 감사합니다 😆
+        제가 클래스를 잘 진행할 수 있도록 간단한 자기소개를 해주세요!
+      </div>
+    </div>
+  );
+}
+
+export default MentoIntro;


### PR DESCRIPTION
# 캠프 신청 페이지

- `/camp/apply` 라우트 등록.
- 멘토의 인사말 컴포넌트 생성.
- 멘티의 본인정보 등록 컴포넌트 생성.
  - 이름 / 연락처 / 이메일 정보 필요

(feature/make-apply-camp-page)