### PR TITLE
feat: Navigation 컴포넌트 분리

### DIFF
--- a/src/commons/layouts/Layout.tsx
+++ b/src/commons/layouts/Layout.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 
-import MainHeader from './components/MainHeader';
+import Navigation from './components/Navigation';
 import Footer from './components/Footer';
 
 function MainLayout() {
   return (
     <div>
       <header>
-        <MainHeader />
+        <Navigation />
       </header>
       <main>
         <Outlet />

--- a/src/commons/layouts/components/Navigation.tsx
+++ b/src/commons/layouts/components/Navigation.tsx
@@ -7,26 +7,13 @@ function Navigation() {
         <span className="header__logo">Co-Lab</span>
         <nav className="header__navigation">
           <ul>
-            <li>🧑‍🦲</li>
+            <li>
+              <button type="button">
+                내 정보
+              </button>
+            </li>
           </ul>
         </nav>
-      </div>
-      <div className="header__combobox">
-        <h1>
-          개발은
-          <br />
-          코랩과 함께
-        </h1>
-        <div>
-          <img
-            src="https://1080motion.com/wp-content/uploads/2018/06/NoImageFound.jpg.png"
-            alt="html"
-            style={{
-              height: '400px',
-              width: '597.51px',
-            }}
-          />
-        </div>
       </div>
     </div>
   );

--- a/src/commons/layouts/components/Navigation.tsx
+++ b/src/commons/layouts/components/Navigation.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-function MainHeader() {
+function Navigation() {
   return (
     <div className="container">
       <div className="header__navigation">
@@ -32,4 +32,4 @@ function MainHeader() {
   );
 }
 
-export default MainHeader;
+export default Navigation;

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 
+import ComboBox from './components/ComboBox';
 import CampCards from './components/CampCards';
 import CommuntyCards from './components/CommuntyCards';
 
 function Home() {
   return (
     <div className="container">
+      <ComboBox />
+
       <section>
         <h2>인기 부트 캠프</h2>
         <CampCards />

--- a/src/pages/Home/components/ComboBox.tsx
+++ b/src/pages/Home/components/ComboBox.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+function ComboBox() {
+  return (
+    <div className="header__combobox">
+      <h1>
+        개발은
+        <br />
+        코랩과 함께
+      </h1>
+      <div>
+        <img
+          src="https://1080motion.com/wp-content/uploads/2018/06/NoImageFound.jpg.png"
+          alt="html"
+          style={{
+            height: '400px',
+            width: '597.51px',
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default ComboBox;


### PR DESCRIPTION
### Navigation 컴포넌트 재정의

- 불필요한 콤보박스는 홈페이지의 컴포넌트로 분리.
- Header(Navigation)의 필요한 부분만 정의.

(feature/modify-navigation-component)
